### PR TITLE
avoid "undefined reference to" error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ DESTDIR ?= /usr
 
 all: envchain
 envchain: $(OBJS)
-	$(CC) $(LDCFLAGS) $(LIBS) -o envchain $(OBJS)
+	$(CC) $(LDCFLAGS) -o envchain $(OBJS) $(LIBS)
 
 %.o: %.c envchain.h
 	$(CC) -c $(CFLAGS) $(CPPFLAGS) -o $@ $<


### PR DESCRIPTION
Fix error on my ubuntu 16.04 box:

@eagletmt WDYT?

```
sorah@debuild-001:~/packages/envchain/envchain$ gcc --version
gcc (Ubuntu 5.3.1-14ubuntu2.1) 5.3.1 20160413
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

```
sorah@debuild-001:~/packages/envchain/envchain$ make
cc  -lreadline `pkg-config --libs libsecret-1` -o envchain envchain.o envchain_linux.o
envchain.o: In function `envchain_ask_value':
/mnt/vol/home/packages/envchain/envchain/envchain.c:130: undefined reference to `readline'
envchain_linux.o: In function `search_unlocked_collection':
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:20: undefined reference to `secret_service_get_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:26: undefined reference to `secret_collection_for_alias_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:29: undefined reference to `g_object_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:34: undefined reference to `secret_collection_get_locked'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:35: undefined reference to `g_list_append'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:38: undefined reference to `secret_collection_get_service'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:37: undefined reference to `secret_service_unlock_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:40: undefined reference to `g_list_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:41: undefined reference to `g_list_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:42: undefined reference to `g_object_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:51: undefined reference to `secret_service_disconnect'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:52: undefined reference to `secret_service_get_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:57: undefined reference to `secret_collection_for_alias_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:60: undefined reference to `g_object_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:66: undefined reference to `g_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:66: undefined reference to `g_str_equal'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:66: undefined reference to `g_str_hash'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:66: undefined reference to `g_hash_table_new_full'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:69: undefined reference to `g_strdup'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:69: undefined reference to `g_strdup'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:69: undefined reference to `g_hash_table_insert'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:71: undefined reference to `secret_collection_search_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:75: undefined reference to `g_hash_table_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:76: undefined reference to `g_object_unref'
envchain_linux.o: In function `envchain_search_namespaces':
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:89: undefined reference to `g_error_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:94: undefined reference to `g_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:94: undefined reference to `g_str_equal'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:94: undefined reference to `g_str_hash'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:94: undefined reference to `g_hash_table_new_full'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:106: undefined reference to `g_hash_table_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:107: undefined reference to `g_list_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:103: undefined reference to `g_hash_table_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:98: undefined reference to `secret_item_get_attributes'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:99: undefined reference to `g_hash_table_lookup'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:99: undefined reference to `g_strdup'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:100: undefined reference to `g_hash_table_add'
envchain_linux.o: In function `envchain_search_values':
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:118: undefined reference to `g_error_free'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:125: undefined reference to `secret_item_get_attributes'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:126: undefined reference to `g_hash_table_lookup'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:127: undefined reference to `secret_item_get_secret'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:128: undefined reference to `secret_value_get_text'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:129: undefined reference to `secret_value_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:130: undefined reference to `g_hash_table_unref'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:133: undefined reference to `g_list_free'
envchain_linux.o: In function `envchain_save_value':
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:148: undefined reference to `secret_password_store_sync'
/mnt/vol/home/packages/envchain/envchain/envchain_linux.c:154: undefined reference to `g_error_free'
collect2: error: ld returned 1 exit status
Makefile:17: recipe for target 'envchain' failed
make: *** [envchain] Error 1
```