### PR TITLE
Add --unset option to remove environment variables

### DIFF
--- a/envchain.c
+++ b/envchain.c
@@ -57,6 +57,8 @@ envchain_abort_with_help(void)
     "    %s NAMESPACE CMD [ARG ...]\n"
     "  List namespaces\n"
     "    %s --list\n"
+    "  Remove variables\n"
+    "    %s --unset NAMESPACE ENV [ENV ..]\n"
     "\n"
     "Options:\n"
     "  --set (-s):\n"
@@ -69,7 +71,7 @@ envchain_abort_with_help(void)
     "    Replace the item's ACL list to require passphrase (or not).\n"
     "    Leave as is when both options are omitted.\n"
     ,
-    envchain_name, version, envchain_name, envchain_name, envchain_name
+    envchain_name, version, envchain_name, envchain_name, envchain_name, envchain_name
   );
   exit(2);
 }
@@ -234,6 +236,28 @@ envchain_list(int argc, const char **argv)
   return 0;
 }
 
+/* functions for --unset */
+
+int
+envchain_unset(int argc, const char **argv)
+{
+  const char *name, *key;
+
+  if (argc < 2) envchain_abort_with_help();
+
+  name = argv[0];
+  argv++; argc--;
+
+  while (0 < argc) {
+    key = argv[0];
+    argv++; argc--;
+
+    envchain_delete_value(name, key);
+  }
+
+  return 0;
+}
+
 /* functions for exec mode */
 
 static void
@@ -290,6 +314,10 @@ main(int argc, const char **argv)
   else if (strcmp(argv[0], "--list") == 0 || strcmp(argv[0], "-l") == 0) {
     argv++; argc--;
     return envchain_list(argc, argv);
+  }
+  else if (strcmp(argv[0], "--unset") == 0) {
+    argv++; argc--;
+    return envchain_unset(argc, argv);
   }
   else if (argv[0][0] == '-') {
     fprintf(stderr, "Unknown option %s\n", argv[0]);

--- a/envchain.h
+++ b/envchain.h
@@ -19,5 +19,6 @@ int envchain_search_values(const char *name, envchain_search_callback callback,
                            void *data);
 void envchain_save_value(const char *name, const char *key, char *value,
                          int require_passphrase);
+void envchain_delete_value(const char *name, const char *key);
 
 #endif

--- a/envchain_linux.c
+++ b/envchain_linux.c
@@ -194,3 +194,14 @@ void envchain_save_value(const char *name, const char *key, char *value,
     g_error_free(error);
   }
 }
+
+void envchain_delete_value(const char *name, const char *key) {
+  GError *error = NULL;
+  secret_password_clear_sync(envchain_get_schema(), NULL, &error,
+                             "name", name, "key", key, NULL);
+  if (error != NULL) {
+    fprintf(stderr, "%s: secret_password_clear_sync failed with %d: %s\n",
+            envchain_name, error->code, error->message);
+    g_error_free(error);
+  }
+}

--- a/envchain_osx.c
+++ b/envchain_osx.c
@@ -453,3 +453,11 @@ fail:
 
   return;
 }
+
+void
+envchain_delete_value(const char *name, const char *key) {
+  SecKeychainItemRef ref = NULL;
+  if (envchain_find_value(name, key, &ref) != 0) {
+    SecKeychainItemDelete(ref);
+  }
+}


### PR DESCRIPTION
It seems like envchain currently doesn't provide a way to remove namespaces or environment variables. Sometimes you may be able to set `""` as a workaround, but `""` vs `null` matters in some applications.

So I added `--unset` option to remove environment variables. You can also clean up namespaces you no longer use from `envchain --list` if you remove all environment variables under a namespace using this feature.

## Example

```
$ ./envchain --set test TEST1 TEST2
test.TEST1: test1
test.TEST2: test2
$ ./envchain --unset test TEST2
$ ./envchain test env | grep TEST
TEST1=test1
```