### PR TITLE
Add KeePassXC to the list of secretservice tools on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Don't give any credentials implicitly!
 - readline
 - libsecret
 - D-Bus Secret Service
-    - GNOME keyring is a common (and only?) implementation for it
+    - GNOME keyring
+    - KeePassXC
 
 ## Installation
 


### PR DESCRIPTION
Thought it might be worth mentioning that KeePassXC (with secret service enabled) works fine with envchain.